### PR TITLE
feat: bump `rise-optimism` to v1.11.1

### DIFF
--- a/chain/rollup.json
+++ b/chain/rollup.json
@@ -37,6 +37,10 @@
     "da_commitment_type": "KeccakCommitment",
     "da_challenge_window": 100,
     "da_resolve_window": 300
+  },
+  "chain_op_config": {
+    "eip1559Elasticity": 6,
+    "eip1559Denominator": 50,
+    "eip1559DenominatorCanyon": 250
   }
 }
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - "./jwt.txt:/config/jwt.txt"
 
   rise-node:
-    image: us-east4-docker.pkg.dev/rise-431614/risechain-public/rise-op-node:v1.9.4
+    image: us-east4-docker.pkg.dev/rise-431614/risechain-public/rise-op-node:v1.11.1
     restart: unless-stopped
     command: >
       op-node


### PR DESCRIPTION
Update for Testnet upgrade following Sepolia Pectra fork.

Proposal PRs: https://github.com/risechain/devops/pull/187