### PR TITLE
fix: incorrect syntax in `tee` command usage

### DIFF
--- a/generate-jwt.sh
+++ b/generate-jwt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [[ ! -f jwt.txt ]]
 then
-  openssl rand -hex 32 | tr -d "\n" | tee > jwt.txt
+  openssl rand -hex 32 | tr -d "\n" | tee jwt.txt
 else
   echo "jwt.txt already exists!"
 fi


### PR DESCRIPTION
corrected an issue where the `tee` command was incorrectly using the `>` symbol for redirection.
the proper approach is to provide the output file as an argument to `tee`, not through redirection.
this fix ensures the command works as expected.