### PR TITLE
fix: docker path regressions from the systemd merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Run a RISE full node, two ways: **Docker Compose** (quickest, bundled monitoring
   - Bare-metal EPYC 9135 / 128GB / 2×1.92TB NVMe RAID0. 
   - Local SSD is ephemeral — if the VM is lost, re-restore from snapshot.
 - **L1 RPC without rate limits** (Sepolia for testnet, Ethereum for mainnet) — best is your own L1 node. A throttled endpoint keeps derivation below chain speed: the node **falls behind forever**. With a paid provider, set `L1_RPC_KIND=<provider>` (+ `L1_TRUST_RPC=true`) in `.env`.
-- **Firewall**: open `30003/tcp` (P2P). Block `8545`/`8546` unless serving RPC. Docker: also block `3000` (Grafana admin/admin), `9090` (Prometheus, no auth), `9001`/`7300`.
+- **Firewall**: open `30003/tcp` (P2P). Block `8545`/`8546` unless serving RPC. Docker: also block `3000` (Grafana admin/admin), `9090` (Prometheus, no auth), `7545`, `9001`/`7300`.
 
 
 
@@ -71,8 +71,9 @@ Switching from a genesis-synced node: stop it, delete `l2_data` + `safedb_data`,
 
 ```sh
 ./generate-jwt.sh
-# use env.mainnet for mainnet; needs docker compose >= 2.17
-docker compose --env-file env.testnet --env-file .env -p rise -f docker-compose.yml -f monitor.yml up -d
+# NETWORK comes from .env; two --env-file needs docker compose >= 2.17
+NETWORK=$(sed -n 's/^NETWORK=//p' .env)
+docker compose --env-file "env.$NETWORK" --env-file .env -p rise -f docker-compose.yml -f monitor.yml up -d
 ```
 
 Grafana at `:3000` (admin/admin).
@@ -84,7 +85,8 @@ Grafana at `:3000` (admin/admin).
 Switching from docker on the same host? Stop the docker stack first — it holds ports 8545/30003 (the installer refuses to start over it):
 
 ```sh
-docker compose -p rise -f docker-compose.yml -f monitor.yml down
+NETWORK=$(sed -n 's/^NETWORK=//p' .env)
+docker compose --env-file "env.$NETWORK" --env-file .env -p rise -f docker-compose.yml -f monitor.yml down
 ```
 
 ```sh
@@ -111,8 +113,9 @@ sudo ./scripts/install.sh          # native — restarts only if something chang
 ```
 
 ```sh
-git pull --ff-only                 # docker — use env.mainnet for mainnet
-docker compose --env-file env.testnet --env-file .env -p rise -f docker-compose.yml -f monitor.yml up -d
+git pull --ff-only                 # docker
+NETWORK=$(sed -n 's/^NETWORK=//p' .env)
+docker compose --env-file "env.$NETWORK" --env-file .env -p rise -f docker-compose.yml -f monitor.yml up -d
 ```
 
 **Rollback / run any version (native)** — pin a tag in `.env` and re-run (remove the pin when done, it freezes upgrades). Use the base tag (`sha-xxxxxxx`) — the installer appends `-amd64`/`-arm64` itself (and strips one if you paste it). Tags: [rise-exec/replica-bin](https://gallery.ecr.aws/risechain/risechain-public/rise-exec/replica-bin) · [rise-op-node-bin](https://gallery.ecr.aws/risechain/risechain-public/rise-op-node-bin).
@@ -138,7 +141,7 @@ Rollback doesn't downgrade the database — if the newer version migrated the da
 | ----------- | ------------- | ---------------------------- |
 | 8545 / 8546 | HTTP RPC / WS | 0.0.0.0 — firewall as needed |
 | 30003       | P2P           | open publicly                |
-| 7545        | op-node RPC   | loopback only                |
+| 7545        | op-node RPC   | loopback only (native)       |
 | 9001 / 7300 | metrics       | loopback only (native)       |
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     container_name: rise-exec
     image: public.ecr.aws/risechain/risechain-public/rise-exec/replica:${RISE_EXEC_TAG:?set via --env-file env.mainnet or env.testnet}
     restart: unless-stopped
+    # reth needs time to flush and close the DB cleanly — don't SIGKILL it early
+    stop_grace_period: 300s
     deploy:
       ## Resource usage and Limit
       # Depend on your system
@@ -67,6 +69,7 @@ services:
       - rise-exec
     image: public.ecr.aws/risechain/risechain-public/rise-op-node:${RISE_NODE_TAG:?set via --env-file env.mainnet or env.testnet}
     restart: unless-stopped
+    stop_grace_period: 60s
     deploy:
       ## Resource usage and Limit
       # Depend on your system
@@ -78,17 +81,16 @@ services:
             cpus: 2
             memory: 12g
     ports:
-      - "7545:7545"       # rpc
-      - "30003:30003/tcp"   # p2p
+      - "7545:7545"       # op-node rpc
+      - "30003:30003/tcp" # p2p
       - "7300:7300"       # metrics
     command:
       - op-node
-      - --l1=${L1_RPC_URL}
+      - --l1=${L1_RPC_URL:?set L1_RPC_URL in .env}
       - --l2=/ipc/auth_reth.ipc
       - --l2.jwt-secret=/config/jwt.txt
       - --rollup.config=/rollup.json
       - --rpc.port=7545
-      - --rpc.enable-admin
       - --p2p.priv.path=/config/p2p-node-key.txt
       - --p2p.static=${P2P_STATIC}
       - --p2p.listen.ip=0.0.0.0

--- a/env.mainnet
+++ b/env.mainnet
@@ -1,13 +1,12 @@
 # RISE Mainnet preset — managed by git, do NOT copy to .env; put your local settings in .env (see env.example)
-L1_RPC_URL=
 CHAIN_CONFIG_DIR=./chain/mainnet
 P2P_STATIC=/ip4/72.251.11.31/tcp/30003/p2p/16Uiu2HAmVM8PM7GAwiCWnS8zT2Jkd3YxaJV51YioGD7Joxgna3BH,/ip4/15.235.228.214/tcp/30003/p2p/16Uiu2HAkyFEFrWE9DRpJQJ7o1D3dfBRerpjSCgp3g8kTtRLRGwJJ
 PUBLIC_RPC=https://rpc.risechain.com
 DA_SERVER=https://da.risechain.com
 
 # Pinned component versions (docker image tag == native binary tag)
-RISE_EXEC_TAG=sha-80d9780
-RISE_NODE_TAG=sha-31f2dcb
+RISE_EXEC_TAG=sha-4d4a693
+RISE_NODE_TAG=sha-ae63731
 
 # RPC tuning
 RPC_GAS_CAP=64000000

--- a/env.testnet
+++ b/env.testnet
@@ -1,5 +1,4 @@
 # RISE Testnet preset (L1 = Sepolia) — managed by git, do NOT copy to .env; put your local settings in .env (see env.example)
-L1_RPC_URL=
 CHAIN_CONFIG_DIR=./chain/testnet
 P2P_STATIC=/ip4/85.195.87.177/tcp/30003/p2p/16Uiu2HAmBsavoZqE4g73wxnVYe7bGXdSQ1LFcuAeLaR9Y4MWx3cQ,/ip4/173.201.39.245/tcp/30003/p2p/16Uiu2HAmCTYuXU9n5xRH5b1siXcVywNo8dAneZcjR7v244zv9ez6,/ip4/103.66.181.195/tcp/30003/p2p/16Uiu2HAmENsvUkP1zNvo2TniEHAjRc71zMSvwqPpQVLtxqLR9D35
 PUBLIC_RPC=https://testnet.riselabs.xyz


### PR DESCRIPTION
- [x] Restore mainnet pins to `sha-4d4a693 / sha-ae63731` — the images for chain upgrade 31 actually shipped.
- [x] Add `stop_grace_period: 300s` to rise-exec and 60s to rise-node — compose SIGKILLs after 10s by default, killing reth mid-flush
- [x] Drop `--rpc.enable-admin` from op-node — a replica doesn't need it.
- [x] Change `--l1=${L1_RPC_URL}` to `${L1_RPC_URL:?...}` so it fails at parse time instead of dying at runtime.
- [x] Remove the empty `L1_RPC_URL=` line from `env.mainnet` and `env.testnet` — an empty preset value blanks the user's .env when the --env-file order is flipped.
- [x] README: derive NETWORK from `.env` in all three docker commands — docker was ignoring that variable entirely.
- [x] README: add `--env-file` to the down command in section 3b — it currently fails, since compose interpolates the project file for every subcommand
- [x] README: ports table now says loopback only (native) for `7545`, and the firewall line lists `7545` for docker
- [x] Rename the `7545` port comment to # op-node rpc (it collided with 8545's # rpc) and align the ports block