### PR TITLE
fix: bind RPC endpoints to localhost by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,11 @@ services:
       - --datadir=/db
       - --http
       - --http.api=eth,web3
-      - --http.addr=0.0.0.0
+      - --http.addr=127.0.0.1
       - --http.port=8545
       - --ws
       - --ws.api=eth,web3
-      - --ws.addr=0.0.0.0
+      - --ws.addr=127.0.0.1
       - --ws.port=8546
       - --authrpc.jwtsecret=/config/jwt.txt
       - --auth-ipc


### PR DESCRIPTION
## Problem

`docker-compose.yml` binds HTTP and WebSocket RPC to `0.0.0.0`:
```yaml
- --http.addr=0.0.0.0
- --ws.addr=0.0.0.0
```

This makes RPC endpoints accessible from the **public internet** without authentication. Combined with `--rpc.enable-admin` on the op-node, this is a significant security risk.

## Fix

Changed bind address to `127.0.0.1` (localhost):
```yaml
- --http.addr=127.0.0.1
- --ws.addr=127.0.0.1
```

## Security Impact

- RPC endpoints are now only accessible from the local machine by default
- Users who need remote access can:
  - Use a reverse proxy (nginx, caddy) with TLS and auth
  - Override the address in their `.env` or docker-compose override
- Metrics endpoints (`0.0.0.0:9001`, `0.0.0.0:7300`) are left as-is since they typically don't expose sensitive operations